### PR TITLE
Update the node sample start command

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -5,4 +5,4 @@ COPY . .
 
 RUN yarn install --frozen-lockfile
 
-CMD ["yarn", "start"]
+CMD ["yarn", "start-env"]

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -32,7 +32,7 @@ install:
 
 .PHONY: run
 run:
-	$(QUIET) yarn start
+	$(QUIET) yarn start-env
 
 .PHONY: build-docker
 build-docker:


### PR DESCRIPTION
## Issue description
The node sample does not start as expected with the given command:
`make build-docker run-docker`

Get the following error:
```
ERROR: index.js - failed to initialise server Error: Environmental Variable 'API_URL' not defined
    at Function.parse (/home/tetsuo/paymentsense/connect-e-samples/nodejs/src/envs.js:35:13)
    at Object.<anonymous> (/home/tetsuo/paymentsense/connect-e-samples/nodejs/src/index.js:11:15)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [Makefile:35: run] Error 1
```
## Solution
nodejs sample repo has a .env file included:
https://github.com/Paymentsense/connect-e-samples/blob/master/nodejs/.env

This .env file is based on the default test JWT provided in the docs:
https://docs.connect.paymentsense.cloud/ConnectE/SettingUpTestAccount

The `start-env` command in the package.json file pulls in these environment variables before starting the project:
https://github.com/Paymentsense/connect-e-samples/blob/master/nodejs/package.json

By having the project start commands use `start-env` instead, the sample works "out of the box".

Alternate solution proposal: we could add instructions to specify how a user could make the .env variables available to the container (if possible?)